### PR TITLE
ENH: Add pypi package summary to meta.yaml

### DIFF
--- a/conda_skeletor/main.py
+++ b/conda_skeletor/main.py
@@ -11,9 +11,10 @@ import tempfile
 import subprocess
 import shutil
 from jinja2 import Environment, FileSystemLoader
-from . import git
 import depfinder
+from . import git
 from . import setup_parser
+from . import pypi
 
 logger = logging.getLogger(__name__)
 
@@ -590,7 +591,16 @@ def execute_programmatically(skeletor_config_path, source_path, output_dir):
 
     template_info['run_requirements'] = run_requires
     template_info['test_requires'] = test_requires
-
+    template_info['lib_descriptions'] = {}
+    # grab the package description from pypi if it exists
+    for lib_name in (set(template_info['run_requirements'] +
+                         template_info['test_requires'] +
+                         template_info['build_requirements'])):
+        try:
+            description = pypi.description(lib_name)
+        except ValueError:
+            description = "A description for %s is not available on pypi" % lib_name
+        template_info['lib_descriptions'][lib_name] = description
     if 'test_imports' not in template_info:
         if is_single_module_package:
             test_imports = [importable_lib_name]

--- a/conda_skeletor/main.py
+++ b/conda_skeletor/main.py
@@ -568,10 +568,13 @@ def execute_programmatically(skeletor_config_path, source_path, output_dir):
     # remap deps
     for k, v in _PACKAGE_MAPPING.items():
         if k in run_requires:
+            logger.info("remapping %s -> %s in run_requires" % (k, v))
             run_requires[run_requires.index(k)] = v
         if k in test_requires:
+            logger.info("remapping %s -> %s in test_requires" % (k, v))
             test_requires[test_requires.index(k)] = v
         if k in build_requirements:
+            logger.info("remapping %s -> %s in build_requires" % (k, v))
             build_requirements[build_requirements.index(k)] = v
 
     template_info['build_requirements'] = build_requirements

--- a/conda_skeletor/pypi.py
+++ b/conda_skeletor/pypi.py
@@ -38,7 +38,7 @@ def description(package_name, pypi_first=False):
             pass
         else:
             # format the summary string and quit the for loop
-            summary = '(%s) %s' % (identifier, summary_string)
+            summary = '%s (%s)' % (summary_string, identifier)
             break
 
     if not summary:

--- a/conda_skeletor/pypi.py
+++ b/conda_skeletor/pypi.py
@@ -12,7 +12,7 @@ CONDA_URL = 'http://repo.continuum.io/pkgs/metadata.json'
 conda_info = None
 
 
-def description(package_name, pypi_first=False):
+def description(package_name, pypi_first=False, split_on_whitespace=True):
     """Get the short summary description of the library called `package_name`
 
     Parameters
@@ -24,8 +24,14 @@ def description(package_name, pypi_first=False):
         Defaults to True.
         If True: Search pypi for the summary first.
         If False: Search conda for the summary first.
+    split_on_whitespace : bool, optional
+        Defaults to True.
+        You would want to split on whitespace if your library has a specified
+        version, such as 'pymongo <3'.
     """
     call_order = [('pypi', _pypi), ('conda', _conda)]
+    if split_on_whitespace:
+        package_name = package_name.split(' ')[0]
 
     if not pypi_first:
         call_order.reverse()

--- a/conda_skeletor/pypi.py
+++ b/conda_skeletor/pypi.py
@@ -1,0 +1,19 @@
+"""Module to grab information from pypi"""
+
+import requests
+import json
+
+
+PYPI_URL = 'https://pypi.python.org/pypi/{}/json'
+
+
+def description(package_name):
+    url = PYPI_URL.format(package_name)
+    info = requests.get(url)
+    if info.status_code == 200:
+        info = json.loads(info.text)
+        return info['info']['summary']
+
+    raise ValueError("Status code returned is %s for url = %s" %
+                     (info.status_code, url))
+

--- a/conda_skeletor/pypi.py
+++ b/conda_skeletor/pypi.py
@@ -2,18 +2,76 @@
 
 import requests
 import json
+import logging
 
+logger = logging.getLogger(__name__)
 
 PYPI_URL = 'https://pypi.python.org/pypi/{}/json'
+CONDA_URL = 'http://repo.continuum.io/pkgs/metadata.json'
+
+conda_info = None
 
 
-def description(package_name):
+def description(package_name, pypi_first=False):
+    """Get the short summary description of the library called `package_name`
+
+    Parameters
+    ----------
+    package_name : str
+        The name of the package. This is the name that you `pip install
+        <package_name>`, not the name that you `import <package_name>`
+    pypi_first : bool, optional
+        Defaults to True.
+        If True: Search pypi for the summary first.
+        If False: Search conda for the summary first.
+    """
+    call_order = [('pypi', _pypi), ('conda', _conda)]
+
+    if not pypi_first:
+        call_order.reverse()
+
+    summary = ''
+    for identifier, call in call_order:
+        try:
+            summary_string = call(package_name)
+        except ValueError:
+            pass
+        else:
+            # format the summary string and quit the for loop
+            summary = '(%s) %s' % (identifier, summary_string)
+            break
+
+    if not summary:
+        # no package info was found, use a default string
+        summary = ('No package info found for %s at any of these locations: '
+                   '%s' % (package_name,
+                           [identifier for identifier, call in call_order]))
+    return summary
+
+
+def _conda(package_name):
+    global conda_info
+    if not conda_info:
+        info = requests.get(CONDA_URL)
+        if info.status_code == 200:
+            conda_info = json.loads(info.text)
+
+    try:
+        summary = conda_info[package_name]['summary']
+    except KeyError:
+        raise ValueError("conda metadata does not contain information on "
+                         "package %s" % package_name)
+
+    return summary
+
+def _pypi(package_name):
     url = PYPI_URL.format(package_name)
     info = requests.get(url)
     if info.status_code == 200:
         info = json.loads(info.text)
         return info['info']['summary']
 
-    raise ValueError("Status code returned is %s for url = %s" %
-                     (info.status_code, url))
-
+    logger.info("Status code returned is %s for url = %s" %
+                (info.status_code, url))
+    raise ValueError('pypi search for info regarding %s was unsuccessful' %
+                     package_name)

--- a/conda_skeletor/templates/meta.tmpl
+++ b/conda_skeletor/templates/meta.tmpl
@@ -18,15 +18,15 @@ build:
 
 requirements:
   build:
-    - python{{ python_version_build }}{% for build_dep in build_requirements | sort %}
-    - {{ build_dep }}{% endfor %}
+    - python{{ python_version_build }}{% for dep in build_requirements | sort %}
+    - {{ dep }} # {{ lib_descriptions[dep] }}{% endfor %}
   run:
-    - python{{ python_version_build }}{% for run_dep in run_requirements | sort %}
-    - {{ run_dep }}{% endfor %}
+    - python{{ python_version_build }}{% for dep in run_requirements | sort %}
+    - {{ dep }} # {{ lib_descriptions[dep] }}{% endfor %}
 
 test:
-  {% if test_requires %}requires:{% for test_require in test_requires | sort %}
-    - {{ test_require }}{% endfor %}
+  {% if test_requires %}requires:{% for dep in test_requires | sort %}
+    - {{ dep }} # {{ lib_descriptions[dep] }}{% endfor %}
 {% endif %}
   {% if test_imports %}imports:{% for test_import in test_imports | sort %}
     - {{ test_import }}{% endfor %}

--- a/conda_skeletor/tests/data/depfinder/target.meta.yaml
+++ b/conda_skeletor/tests/data/depfinder/target.meta.yaml
@@ -18,18 +18,17 @@ build:
 requirements:
   build:
     - python
-    - setuptools
-    - stdlib-list
+    - setuptools # Easily download, build, install, upgrade, and uninstall Python packages (conda)
+    - stdlib-list # A list of Python Standard Libraries (2.6-7, 3.2-5). (pypi)
   run:
     - python
-    - stdlib-list
+    - stdlib-list # A list of Python Standard Libraries (2.6-7, 3.2-5). (pypi)
 
 test:
   requires:
-    - nbformat
-    - pytest
-    - stdlib-list
-    - test_with_code
+    - nbformat # the base implementation of the Jupyter Notebook format (conda)
+    - pytest # simple powerful testing with Python (conda)
+    - test_with_code # No package info found for test_with_code at any of these locations: ['conda', 'pypi']
 
   imports:
     - depfinder

--- a/conda_skeletor/tests/data/metadatastore/target.meta.yaml
+++ b/conda_skeletor/tests/data/metadatastore/target.meta.yaml
@@ -21,24 +21,18 @@ requirements:
     - python
   run:
     - python
-    - boltons
-    - mongoengine
-    - pymongo <3
-    - pytz
-    - pyyaml
-    - six
+    - boltons # When they're not builtins, they're boltons. (pypi)
+    - mongoengine # MongoEngine is a Python Object-Document Mapper for working with MongoDB. (pypi)
+    - pymongo <3 # Python driver for MongoDB (conda)
+    - pytz # World timezone definitions, modern and historical (conda)
+    - pyyaml # YAML parser and emitter for Python (conda)
+    - six # Python 2 and 3 compatibility utilities (conda)
 
 test:
   requires:
-    - boltons
-    - coverage
-    - mongoengine
-    - nose
-    - numpy
-    - pymongo <3
-    - pytz
-    - pyyaml
-    - six
+    - coverage # Code coverage measurement for Python (conda)
+    - nose # nose extends unittest to make testing easier (conda)
+    - numpy # array processing for numbers, strings, records, and objects. (conda)
 
   imports:
     - metadatastore

--- a/conda_skeletor/tests/data/skxray/target.meta.yaml
+++ b/conda_skeletor/tests/data/skxray/target.meta.yaml
@@ -18,28 +18,22 @@ build:
 requirements:
   build:
     - python
-    - numpy
-    - setuptools
-    - six
+    - numpy # array processing for numbers, strings, records, and objects. (conda)
+    - setuptools # Easily download, build, install, upgrade, and uninstall Python packages (conda)
+    - six # Python 2 and 3 compatibility utilities (conda)
   run:
     - python
-    - lmfit
-    - netcdf4
-    - numpy
-    - scipy
-    - six
-    - xraylib
+    - lmfit # Least-Squares Minimization with Bounds and Constraints (pypi)
+    - netcdf4 # python/numpy interface to netCDF library (conda)
+    - numpy # array processing for numbers, strings, records, and objects. (conda)
+    - scipy # Scientific Library for Python (conda)
+    - six # Python 2 and 3 compatibility utilities (conda)
+    - xraylib # No package info found for xraylib at any of these locations: ['conda', 'pypi']
 
 test:
   requires:
-    - lmfit
-    - netcdf4
-    - nose
-    - numpy
-    - scikit-image
-    - scipy
-    - six
-    - xraylib
+    - nose # nose extends unittest to make testing easier (conda)
+    - scikit-image # Image processing routines for SciPy (conda)
 
   imports:
     - skxray


### PR DESCRIPTION
The relevant portion of the meta.yaml now looks like this:

```
requirements:
  build:
    - python
    - numpy # NumPy: array processing for numbers, strings, records, and objects.
    - setuptools # Easily download, build, install, upgrade, and uninstall Python packages
    - six # Python 2 and 3 compatibility utilities
  run:
    - python
    - lmfit # Least-Squares Minimization with Bounds and Constraints
    - netcdf4 # python/numpy interface to netCDF  library (versions 3 and 4)
    - numpy # NumPy: array processing for numbers, strings, records, and objects.
    - scipy # SciPy: Scientific Library for Python
    - six # Python 2 and 3 compatibility utilities
    - xraylib # A description for xraylib is not available on pypi

test:
  requires:
    - nose # nose extends unittest to make testing easier
    - scikit-image # Image processing routines for SciPy
```

Closes #9 
